### PR TITLE
improves timer efficiency, fixes overflow

### DIFF
--- a/CANTroller2/src/globals.h
+++ b/CANTroller2/src/globals.h
@@ -170,11 +170,11 @@ Preferences config;
 
 // Globals -------------------
 //
-class Timer {  // 32 bit microsecond timer overflows after 71.5 minutes
+class Timer {
   protected:
-    volatile uint32_t start_us = 0;
+    volatile uint64_t start_us = 0;
     volatile uint32_t timeout_us = 0;
-    volatile int64_t target_time = 0;
+    volatile uint64_t target_time = 0;
   public:
     Timer (void) {
         reset();
@@ -187,17 +187,12 @@ class Timer {  // 32 bit microsecond timer overflows after 71.5 minutes
         reset();
     }
     IRAM_ATTR void reset (void) {
-        target_time = start_us + timeout_us;
         start_us = esp_timer_get_time();
+        target_time = start_us + timeout_us;
     }
     IRAM_ATTR bool expired (void) {
         int64_t current_time = esp_timer_get_time();
-
-        // Check for no overflow first
-        if (current_time >= start_us && current_time < target_time) {
-            return false;
-        }
-        return true;
+        return (current_time >= target_time);
     }
     IRAM_ATTR uint32_t elapsed (void) {
         return esp_timer_get_time() - start_us;


### PR DESCRIPTION
Moving the calculation of target_time out of expired() and into reset() could improve efficiency. This is because reset() is called less frequently than expired(), and moving the calculation would reduce the amount of work done each time expired() is called.

Using 64 bit uints also removes the need for the overflow handling

Allocating the variables on instantiation instead of in a function is also neater and saves re-allocating with each call