### PR TITLE
Bobby selectable display driver

### DIFF
--- a/CANTroller2/platformio.ini
+++ b/CANTroller2/platformio.ini
@@ -26,6 +26,7 @@ upload_speed = 900000
 lib_deps = 
 	adafruit/SdFat - Adafruit Fork@^2.2.1
 	adafruit/Adafruit FT6206 Library@^1.0.6
+	adafruit/Adafruit ILI9341@^1.5.12
 	adafruit/Adafruit NeoPixel@^1.11.0
 	adafruit/Adafruit SleepyDog Library@^1.6.4
 	paulstoffregen/XPT2046_Touchscreen @ 0.0.0-alpha+sha.26b691b2c8

--- a/CANTroller2/src/cantroller2.cpp
+++ b/CANTroller2/src/cantroller2.cpp
@@ -24,8 +24,14 @@ void loop_savetime (uint32_t timesarray[], int32_t &index, vector<string> &names
 HotrcManager hotrcHorzManager (22);
 HotrcManager hotrcVertManager (22);
 //Hotrc hotrc (&hotrc_vert_pulse_filt_us, hotrc_pulse_failsafe_min_us, hotrc_pulse_failsafe_max_us, hotrc_pulse_failsafe_pad_us);
-    
-Display screen;
+
+
+#ifdef USE_TFT_DISPLAY_DRIVER
+    Display screen; // TFT-eSPI video driver
+#else    
+    Display screen(tft_cs_pin, tft_dc_pin); // Adafruit video driver
+#endif
+
 TouchScreen ts(touch_cs_pin, touch_irq_pin);
     
 Encoder encoder(encoder_a_pin, encoder_b_pin, encoder_sw_pin);

--- a/CANTroller2/src/display.h
+++ b/CANTroller2/src/display.h
@@ -6,10 +6,14 @@
 // #include <font_Arial.h> // from ILI9341_t3
 // #include <SPI.h>
 
-// #include <Adafruit_ILI9341.h>
-#include <TFT_eSPI.h>
-
 #include "globals.h"
+
+#define USE_TFT_DISPLAY_DRIVER // comment this out to use Adafruit display driver
+#ifdef USE_TFT_DISPLAY_DRIVER
+  #include <TFT_eSPI.h>
+#else 
+  #include <Adafruit_ILI9341.h>
+#endif
 
 // display related globals
 #define BLK  0x0000
@@ -221,11 +225,12 @@ int32_t shutdown_color = colorcard[SHUTDOWN];
 
 class Display {
     private:
-        // Adafruit_ILI9341 _tft (tft_cs_pin, tft_dc_pin, tft_rst_pin); // LCD screen
-        // Adafruit_ILI9341 _tft; // LCD screen
-        TFT_eSPI _tft; // LCD screen
-
-        // ILI9341_t3 _tft;
+        #ifdef USE_TFT_DISPLAY_DRIVER
+            TFT_eSPI _tft; // LCD screen
+        #else
+            Adafruit_ILI9341 _tft; // LCD screen
+        #endif
+        
         Timer _tftResetTimer;
         Timer _tftDelayTimer;
         int32_t _timing_tft_reset;
@@ -233,8 +238,11 @@ class Display {
         bool _disp_redraw_all = true;
     public:
 
-        Display (int8_t cs_pin, int8_t dc_pin) : _tft(cs_pin, dc_pin), _tftResetTimer(100000), _tftDelayTimer(3000000), _timing_tft_reset(0){}
-        Display () : _tft(), _tftResetTimer(100000), _tftDelayTimer(3000000), _timing_tft_reset(0){}
+        #ifdef USE_TFT_DISPLAY_DRIVER
+            Display () : _tft(), _tftResetTimer(100000), _tftDelayTimer(3000000), _timing_tft_reset(0){}
+        #else
+            Display (int8_t cs_pin, int8_t dc_pin) : _tft(cs_pin, dc_pin), _tftResetTimer(100000), _tftDelayTimer(3000000), _timing_tft_reset(0){}
+        #endif        
 
         void init() {
             printf ("Init LCD... ");

--- a/CANTroller2/src/touchScreen.h
+++ b/CANTroller2/src/touchScreen.h
@@ -1,3 +1,5 @@
+#include <globals.h> // should we split out Timer and not include globals? 
+#include "display.h"
 #ifdef CAP_TOUCH
     #include <Adafruit_FT6206.h>  // For interfacing with the capacitive touchscreen controller chip
 #else

--- a/CANTroller2/src/touchScreen.h
+++ b/CANTroller2/src/touchScreen.h
@@ -1,5 +1,3 @@
-#include <globals.h> // should we split out Timer and not include globals? 
-#include "display.h"
 #ifdef CAP_TOUCH
     #include <Adafruit_FT6206.h>  // For interfacing with the capacitive touchscreen controller chip
 #else


### PR DESCRIPTION
Adds the option of using Adafruit or tft-eSPI (Default) with #define USE_TFT_DISPLAY_DRIVER
Comment that define line out to go back to Adafruit