### PR TITLE
Implement BrakePositionSensor

### DIFF
--- a/CANTroller2/src/RunModeManager.h
+++ b/CANTroller2/src/RunModeManager.h
@@ -246,7 +246,7 @@ private:
         else if (calmode_request) updateMode(SHUTDOWN);
         
         if (!cal_pot_gas_ready) {
-            float temp = map (pot.get_filtered_value(), pot.get_min_human(), pot.get_max_human(), (float)gas_pulse_ccw_max_us, (float)gas_pulse_cw_min_us);
+            float temp = pot.mapToRange(gas_pulse_ccw_max_us, gas_pulse_cw_min_us);
             if (temp <= (float)gas_pulse_idle_us && temp >= (float)gas_pulse_redline_us) cal_pot_gas_ready = true;
         }
     }

--- a/CANTroller2/src/devices.h
+++ b/CANTroller2/src/devices.h
@@ -9,6 +9,7 @@
 #include <memory> // for std::shared_ptr
 #include "Arduino.h"
 #include "utils.h"
+#include "uictrl.h"
 // #include "xtensa/core-macros.h"  // access to ccount register for esp32 timing ticks
 
 // Param is a value which is constrained between min/max limits, representing a "raw" (aka unfiltered) quantity. A value with tight limits
@@ -120,19 +121,29 @@ enum class ControllerMode : uint8_t {UNDEF=0, FIXED, PIN, TOUCH, POT, CALC};
 class Device {
   protected:
     // Which types of sources are possible for this device?
+    uint8_t _pin;
+    bool _enabled = true;
+    Potentiometer* _pot; // to pull input from the pot if we're in simulation mode
+    ControllerMode _source = ControllerMode::UNDEF;
     bool _can_source[6] = { true,       // UNDEF
                             true,       // FIXED
                             false,      // PIN
                             true,       // TOUCH
                             false,      // POT
                             false };    // CALC
-    ControllerMode _source = ControllerMode::UNDEF;
-    uint8_t _pin;
-    bool _enabled = true;
+
+    // source handling functions (should be overridden in child classes as needed)
+    virtual void handle_undef_mode() {}
+    virtual void handle_fixed_mode() {}
+    virtual void handle_pin_mode() {}
+    virtual void handle_touch_mode() {}
+    virtual void handle_pot_mode() {}
+    virtual void handle_calc_mode() {}
   public:
     Timer timer;  // Can be used for external purposes
 
     Device() = delete; // should always be created with a pin
+    // NOTE: should we start in PIN mode?
     Device(uint8_t arg_pin) : _pin(arg_pin) {}
 
     bool can_source(ControllerMode arg_source) { return _can_source[static_cast<uint8_t>(arg_source)]; }
@@ -142,6 +153,37 @@ class Device {
             return true;
         } 
         return false;
+    }
+
+    void update() {
+        if (!_enabled) return; // do nothing if the Device is disabled
+        switch (_source) {
+            case ControllerMode::UNDEF:
+                handle_undef_mode();
+                break;
+            case ControllerMode::FIXED:
+                handle_fixed_mode();
+                break;
+            case ControllerMode::PIN:
+                handle_pin_mode();
+                break;
+            case ControllerMode::TOUCH:
+                handle_touch_mode();
+                break;
+            case ControllerMode::POT:
+                handle_pot_mode();
+                break;
+            case ControllerMode::CALC:
+                handle_calc_mode();
+                break;
+            default:
+                // should never get here
+                printf("invalid Device source: %d\n", _source);
+        }
+    }
+
+    void set_pot_input(Potentiometer &pot_arg) {
+        _pot = &pot_arg;
     }
 
     void set_enabled(bool arg_enable) { _enabled = arg_enable; }
@@ -158,120 +200,66 @@ enum class TransducerDirection : uint8_t {REV, FWD}; // possible dir values. REV
 template<typename NATIVE_T, typename HUMAN_T>
 class Transducer : public Device {
   protected:
-    // TODO: move these into a child class as needed
-    // float m_factor = 1.0, b_offset = 0.0;  // Multiplier and adder values to plug in for unit conversion math
-    // bool invert = false;  // Flag to indicated if unit conversion math should multiply or divide
-    // float native_to_human(float arg_val_native) {
-    //     if (!invert) {
-    //         if (dir == REV) return min_native->get() + (max_native->get() - (b_offset + m_factor * arg_val_native));
-    //         return b_offset + m_factor * arg_val_native;
-    //         // if (dir == REV) return *p_min_native + (*p_max_native - (b_offset + m_factor * arg_val_native));
-    //         // return b_offset + m_factor * arg_val_native;
-    //     }
-    //     if (arg_val_native) {
-    //         if (dir == REV) return min_native->get() + (max_native->get() - (b_offset + m_factor / arg_val_native));
-    //         return b_offset + m_factor/arg_val_native;
-    //         // if (dir == _REV) return *p_min_native + (*p_max_native - (b_offset + m_factor / arg_val_native));
-    //         // return b_offset + m_factor/arg_val_native;
-    //     } 
-    //     printf ("Error: unit conversion refused to divide by zero\n");
-    //     return -1;
-    // }
-    // float human_to_native(float arg_val_human) {
-    //     if (dir == REV) {
-    //         arg_val_human = min_native->get() + (max_native->get() - arg_val_human);
-    //     }
-    //     // if (dir == _REV) arg_val_human = *p_min_native + (*p_max_native - arg_val_human);
-    //     if (invert && (arg_val_human - b_offset)) {
-    //         return m_factor / (arg_val_human - b_offset);
-    //     } else if (!invert && m_factor) {
-    //         return (arg_val_human - b_offset) / m_factor;
-    //     }
-    //     // if (invert && (arg_val_human - b_offset)) return m_factor / (arg_val_human - b_offset);
-    //     // if (invert && (arg_val_human - b_offset)) return m_factor / (arg_val_human - b_offset);
-    //     // else if (!invert && m_factor) return (arg_val_human - b_offset) / m_factor;
-    //     printf ("Error: unit conversion refused to divide by zero\n");
-    //     return -1;
-    // }
-    //
-    // // Convert units from base numerical value to disp units:  val_native = m-factor*val_numeric + offset  -or-  val_native = m-factor/val_numeric + offset  where m-factor, b-offset, invert are set here
-    // void set_convert(float arg_m_factor, float arg_b_offset, bool arg_invert) {
-    //     m_factor = arg_m_factor;
-    //     b_offset = arg_b_offset;
-    //     invert = arg_invert;
-    //     // NOTE: this isn't changing here, it should probably be set elsewhere
-    //     // dir = (human_to_native(min_human->get()) <= human_to_native(max_human->get())) ? FWD : REV;
-    //     // NOTE: what is this supposed to be doing?
-    //     // *p_min_native = human_to_native ((dir == _FWD) ? *p_min_human : *p_max_human);
-    //     // *p_max_native = human_to_native ((dir == _FWD) ? *p_max_human : *p_min_human);
+    // Multiplier and adder values to plug in for unit conversion math
+    float _m_factor;
+    float _b_offset;  
+    bool _invert;  // Flag to indicated if unit conversion math should multiply or divide
+    TransducerDirection dir = TransducerDirection::FWD; // NOTE: what is this for, exactly?
+    
+    // conversion functions (can be overridden in child classes different conversion methods are needed)
+    virtual HUMAN_T from_native(NATIVE_T arg_val_native) {
+        float arg_val_f = static_cast<float>(arg_val_native); // convert everything to floats so we don't introduce rounding errors
+        float min_f = static_cast<float>(native.get_min());
+        float max_f = static_cast<float>(native.get_max());
+        float ret = -1;
+        if (!_invert) {
+            if (dir == TransducerDirection::REV) {
+                ret = min_f + (max_f - (_b_offset + (_m_factor * arg_val_f)));
+            }
+            ret = _b_offset + (_m_factor * arg_val_f);
+        } else if (arg_val_f) { // NOTE: isn't 0.0 a valid value tho?
+            if (dir == TransducerDirection::REV) {
+                ret = min_f + (max_f - (_b_offset + (_m_factor / arg_val_f)));
+            }
+            ret = _b_offset + (_m_factor / arg_val_f);
+        } else {
+            printf ("Error: unit conversion refused to divide by zero\n");
+            // NOTE: hmmmm, couldn't -1 be a valid value in some caes?
+        }
+        return static_cast<HUMAN_T>(ret);
+    }
 
-    //     
-    //     native.set(human_to_native(human.get()));
-    // }
-
-        // virtual HUMAN_T from_native(NATIVE_T arg_val_native) {
-        //     float arg_val_f = static_cast<float>(arg_val_native);
-        //     float min_f = static_cast<float>(native.get_min());
-        //     float max_f = static_cast<float>(native.get_max());
-        //     float ret = -1;
-        //     if (!_invert) {
-        //         if (dir == TransducerDirection::REV) {
-        //             ret = min_f + (max_f - (_b_offset + (_m_factor * arg_val_f)));
-        //         }
-        //         ret = _b_offset + (_m_factor * arg_val_f);
-        //     } else if (arg_val_f) { // NOTE: isn't 0.0 a valid value tho?
-        //         if (dir == TransducerDirection::REV) {
-        //             ret = min_f + (max_f - (_b_offset + (_m_factor / arg_val_f)));
-        //         }
-        //         ret = _b_offset + (_m_factor / arg_val_f);
-        //     } else {
-        //         printf ("Error: unit conversion refused to divide by zero\n");
-        //         // NOTE: hmmmm, couldn't -1 be a valid value in some caes?
-        //     }
-        //     return static_cast<HUMAN_T>(ret);
-        // }
-
-        // virtual NATIVE_T to_native(HUMAN_T arg_val_human) {
-        //     float arg_val_f = static_cast<float>(arg_val_human);
-        //     float min_f = static_cast<float>(human.get_min());
-        //     float max_f = static_cast<float>(human.get_max());
-        //     float ret = -1;
-        //     if (dir == TransducerDirection::REV) {
-        //         arg_val_f = min_f + (max_f - arg_val_f);
-        //     }
-        //     if (_invert && (arg_val_f - _b_offset)) {
-        //         ret = _m_factor / (arg_val_f - _b_offset);
-        //     } else if (!_invert && _m_factor) {
-        //         ret = (arg_val_f - _b_offset) / _m_factor;
-        //     } else {
-        //         printf ("Error: unit conversion refused to divide by zero\n");
-        //         // NOTE: hmmmm, couldn't -1 be a valid value in some caes?
-        //     }
-        //     return static_cast<NATIVE_T>(ret);
-        // }
+    virtual NATIVE_T to_native(HUMAN_T arg_val_human) {
+        float arg_val_f = static_cast<float>(arg_val_human); // convert everything to floats so we don't introduce rounding errors
+        float min_f = static_cast<float>(human.get_min());
+        float max_f = static_cast<float>(human.get_max());
+        float ret = -1;
+        if (dir == TransducerDirection::REV) {
+            arg_val_f = min_f + (max_f - arg_val_f);
+        }
+        if (_invert && (arg_val_f - _b_offset)) {
+            ret = _m_factor / (arg_val_f - _b_offset);
+        } else if (!_invert && _m_factor) {
+            ret = (arg_val_f - _b_offset) / _m_factor;
+        } else {
+            printf ("Error: unit conversion refused to divide by zero\n");
+            // NOTE: hmmmm, couldn't -1 be a valid value in some caes?
+        }
+        return static_cast<NATIVE_T>(ret);
+    }
 
     // NOTE: do we really need two values? or should this just be a single value and get converted wherever needed?
     // To hold val/min/max display values in display units (like V, mph, etc.)
     Param<HUMAN_T> human;
     Param<NATIVE_T> native;
-
-    TransducerDirection dir = TransducerDirection::FWD; // Belongs in a child class for devices. For the case a lower val causes a higher real-life effect, 
-
-    virtual HUMAN_T from_native(NATIVE_T arg_val_native) = 0;
-    virtual NATIVE_T to_native(HUMAN_T arg_val_native) = 0;
-
   public:
     Transducer(uint8_t arg_pin) : Device(arg_pin) {}
     Transducer() = delete;
 
-    // NOTE: do we want to be able to set min/max separately?
-    // NOTE: do we want to be able to have limits maintained internally (so not references)?
-    // NOTE: since we really only have one value and two representations, should these limit calls change both limits?
     void set_native_limits(Param<NATIVE_T> &arg_min, Param<NATIVE_T> &arg_max) {
         if (arg_min.get() > arg_max.get()) {
             dir = TransducerDirection::REV;
             native.set_limits(arg_max, arg_min);
-            // NOTE: should change the human val as well if constrained
         }
         else {
             dir = TransducerDirection::FWD;
@@ -318,6 +306,13 @@ class Transducer : public Device {
         return false;
     }
 
+    // Convert units from base numerical value to disp units:  val_native = m-factor*val_numeric + offset  -or-  val_native = m-factor/val_numeric + offset  where m-factor, b-offset, invert are set here
+    void set_convert(float arg_m_factor, float arg_b_offset, bool arg_invert) {
+        _m_factor = arg_m_factor;
+        _b_offset = arg_b_offset;
+        _invert = arg_invert;
+    }
+
     NATIVE_T get_native() { return native.get(); }
     HUMAN_T get_human() { return human.get(); }
     NATIVE_T get_min_native() { return native.get_min(); }
@@ -350,352 +345,39 @@ class Sensor : public Transducer<NATIVE_T, HUMAN_T> {
     std::shared_ptr<HUMAN_T> get_filtered_value_ptr() { return _val_filt.get_ptr(); } // NOTE: should just be public?
 };
 
-// Potentiometer does an analog read from a pin and maps it to a percent (0%-100%). We filter the value to keep it smooth. The output can either be read as a value, or passed as a pointer so that other components can
-// access it directly as needed.
-class Potentiometer : public Sensor<int32_t, float> {
-    protected:
-        // Multiplier and adder values to plug in for unit conversion math
-        float _m_factor;
-        float _b_offset;  
-        bool _invert;  // Flag to indicated if unit conversion math should multiply or divide
-
-        virtual float from_native(int32_t arg_val_native) {
-            float arg_val_f = static_cast<float>(arg_val_native);
-            float min_f = static_cast<float>(native.get_min());
-            float max_f = static_cast<float>(native.get_max());
-            return map(arg_val_f, min_f, max_f, human.get_min(), human.get_max());
-        }
-    
-        virtual int32_t to_native(float arg_val_human) {
-            float min_f = static_cast<float>(native.get_min());
-            float max_f = static_cast<float>(native.get_max());
-            return static_cast<int32_t>(map(arg_val_human, human.get_min(), human.get_max(), min_f, max_f));
-        }
-    public:
-        static constexpr float percent_min = 0.0, percent_max = 100;
-        static constexpr int32_t adc_min = 300; // TUNED 230603 - Used only in determining theconversion factor
-        static constexpr int32_t adc_max = 4095; // TUNED 230613 - adc max measured = ?, or 9x.? % of adc_range. Used only in determining theconversion factor
-
-        static constexpr float initial_percent_per_adc = (percent_max - percent_min) / (adc_max - adc_min);  // 100 % / (3996 adc - 0 adc) = 0.025 %/adc
-        static constexpr float initial_ema_alpha = 0.1;
-        static constexpr float initial_offset = -0.08;
-        static constexpr bool initial_invert = false;
-
-        Potentiometer(uint8_t arg_pin) : Sensor<int32_t, float>(arg_pin) {
-            _ema_alpha = initial_ema_alpha;
-            _m_factor = initial_percent_per_adc;
-            _b_offset = initial_offset;
-            _invert = initial_invert;
-            native.set_limits(adc_min, adc_max);
-            human.set_limits(percent_min, percent_max);
-            set_native(adcmidscale_adc);
-            set_can_source(ControllerMode::PIN, true);
-        }
-
-        void setup() {
-            set_pin(_pin, INPUT);
-            set_source(ControllerMode::PIN);
-        }
-    
-        void read() {
-            set_native(analogRead(_pin));
-            ema(human.get());
-        }
-
-        // Convert units from base numerical value to disp units:  val_native = m-factor*val_numeric + offset  -or-  val_native = m-factor/val_numeric + offset  where m-factor, b-offset, invert are set here
-        void set_convert(float arg_m_factor, float arg_b_offset, bool arg_invert) {
-            _m_factor = arg_m_factor;
-            _b_offset = arg_b_offset;
-            _invert = arg_invert;
-            set_native(native.get());
-        }
-};
-
-// These enum classes represent the components which can be simulated (SimOption) and the subset of those components which can be take simulated input from the pot (PotOption).
-// They are both uint8_t types under the covers, and PotOption has all of its members defined to match the values of its SimOption counterparts, so they can be compared and
-// used interchangeably, albeit with casts from one type to the other. Two converter functions are provided as helpers with casting if desired (sim2pot and pot2sim).
-typedef uint8_t opt_t;
-enum class SimOption : opt_t { pressure=0, brkpos, tach, airflow, speedo, battery, coolant, joy, basicsw, cruisesw, syspower, starter, ignition };
-enum class PotOption : opt_t { pressure=static_cast<opt_t>(SimOption::pressure),
-                               brkpos=static_cast<opt_t>(SimOption::brkpos),
-                               tach=static_cast<opt_t>(SimOption::tach), 
-                               airflow=static_cast<opt_t>(SimOption::airflow), 
-                               speedo=static_cast<opt_t>(SimOption::speedo), 
-                               battery=static_cast<opt_t>(SimOption::battery), 
-                               coolant=static_cast<opt_t>(SimOption::coolant),
-                               none=static_cast<opt_t>(-1) };
-PotOption sim2pot(SimOption option) { return static_cast<PotOption>(static_cast<opt_t>(option)); }
-SimOption pot2sim(PotOption option) { return static_cast<SimOption>(static_cast<opt_t>(option)); }
-
-// Simulator manages the ControllerMode handling logic for all simulatable components. Currently, components can recieve simulated input from either the touchscreen, or from
-// NOTE: this class is designed to be backwards-compatible with existing code, which does everything with global booleans. if/when we switch all our Devices to use ControllerModes,
-//       we can simplify the logic here a lot.
-class Simulator {
-    private:
-        // NOTE: if we only simulated devices, we could keep track of simulability in the Device class. We could keep the default ControllerMode in Device the same way.
-        // 3-tuple for a given component, keeping track of simulability status (whether this component is allowed to be simulated), an associated Device (a pointer to the actual component),
-        // and a default ControllerMode (the mode we would like the component to switch back to when it stops being simulated)
-        typedef std::tuple<bool, Device*, ControllerMode> simulable_t;
-        std::map<SimOption, simulable_t> _devices; // a collection of simulatable components
-        bool _enabled = false; // keep track of whether the simulator is running or not
-        SimOption _pot_overload; // keep track of which component is getting info from the pot
-
-        // NOTE: I think we should keep the pot internally here, but there are some logic questions to answer about how that should work.
-        //       For now, keep this class to just managing the logic.
-        // Potentiometer _pot;
-    public:
-        static constexpr PotOption initial_pot_overload = PotOption::speedo;
-        
-        // initial simulation settings
-        static constexpr bool initial_sim_joy = false;
-        static constexpr bool initial_sim_tach = true;
-        static constexpr bool initial_sim_speedo = true;
-        static constexpr bool initial_sim_brkpos = true;
-        static constexpr bool initial_sim_basicsw = true;
-        static constexpr bool initial_sim_cruisesw = false;
-        static constexpr bool initial_sim_pressure = true;
-        static constexpr bool initial_sim_syspower = true;
-        static constexpr bool initial_sim_starter = true;
-        static constexpr bool initial_sim_ignition = true;
-        static constexpr bool initial_sim_airflow = false;
-        static constexpr bool initial_sim_battery = true;
-        static constexpr bool initial_sim_coolant = true;
-
-        Simulator(PotOption overload_arg=initial_pot_overload) : _pot_overload(pot2sim(overload_arg)) {
-            // set initial simulatability status for all components
-            set_can_simulate(SimOption::joy, initial_sim_joy);
-            set_can_simulate(SimOption::tach, initial_sim_tach);
-            set_can_simulate(SimOption::speedo, initial_sim_speedo);
-            set_can_simulate(SimOption::brkpos, initial_sim_brkpos);
-            set_can_simulate(SimOption::basicsw, initial_sim_basicsw);
-            set_can_simulate(SimOption::cruisesw, initial_sim_cruisesw);
-            set_can_simulate(SimOption::pressure, initial_sim_pressure);
-            set_can_simulate(SimOption::syspower, initial_sim_syspower);
-            set_can_simulate(SimOption::starter, initial_sim_starter);
-            set_can_simulate(SimOption::ignition, initial_sim_ignition);
-            set_can_simulate(SimOption::airflow, initial_sim_airflow);
-            set_can_simulate(SimOption::battery, initial_sim_battery);
-            set_can_simulate(SimOption::coolant, initial_sim_coolant);
-        }
-
-        // turn on the simulator. all components which are set to be simulated will switch to simulated input
-        void enable() {
-            if (!_enabled) {
-                for ( auto &kv : _devices ) { // go through all our components
-                    bool can_sim = std::get<0>(kv.second); // check simulatability status
-                    if (can_sim && _pot_overload != kv.first) { // if component has simulation enabled and it's not being overloaded by the pot...
-                        Device *d = std::get<1>(kv.second);
-                        // NOTE: the nullptr checks here and below exist so that we can work with boolean components as well as Devices, for backwards compatability
-                        if (d != nullptr) {
-                           d->set_source(ControllerMode::TOUCH); // ...then set component to take input from the touchscreen
-                        }
-                    }
-                }
-                _enabled = true;
-            }
-        }
-
-        // turn off the simulator. all devices will be set to their default input (if they are not being overloaded by the pot)
-        void disable() {
-            if (_enabled) {
-                for ( auto &kv : _devices ) { // go through all our components
-                    bool can_sim = std::get<0>(kv.second);
-                    if (can_sim && _pot_overload != kv.first) { // if component has simulation enabled and it's not being overloaded by the pot...
-                        Device *d = std::get<1>(kv.second);
-                        if (d != nullptr) {
-                            ControllerMode default_mode = std::get<2>(kv.second);
-                            d->set_source(default_mode); // ...then it's in simulation mode and needs to be set back to it's default mode, since we are no longer simulating
-                        }
-                    }
-                }
-                _enabled = false;
-            }
-        }
-
-        // toggle the simulator on and off
-        void toggle() {
-            return _enabled ? disable() : enable();
-        }
-
-        // check if a componenet is currently being simulated (by either the touchscreen or the pot)
-        bool simulating(SimOption option) {
-            return can_simulate(option) && (_enabled || _pot_overload == option);
-        }
-
-        // associate a Device and a given fall-back ControllerMode with a SimOption
-        void register_device(SimOption option, Device *d, ControllerMode default_mode) {
-            // should we call d.set_can_source here?
-            bool can_sim = false; // by default, disable simulation for this component
-            auto kv = _devices.find(option); // look for the component
-            if (kv != _devices.end()) {
-                can_sim = std::get<0>(kv->second); // if an entry for the component already existed, preserve its simulatability status
-            }
-            _devices[option] = simulable_t(can_sim, d, default_mode); // store info for this component
-        }
-
-        // check if a component can be simulated (by either the touchscreen or the pot)
-        bool can_simulate(SimOption option) {
-            auto kv = _devices.find(option); // look for the component
-            if (kv != _devices.end()) {
-                return std::get<0>(kv->second); // if it exists, check the simulability status
-            }
-            return false; // couldn't find component, so there's no way we can simulate it
-        }
-
-        // set simulatability status for a component
-        void set_can_simulate(SimOption option, bool can_sim) {
-            auto kv = _devices.find(option); // look for component
-            if (kv != _devices.end()) { // if an entry for this component already exists, check if the new simulatability status is different from the old
-                bool old_can_sim = std::get<0>(kv->second);
-                if (can_sim != old_can_sim) { // if the simulation status has changed, we need to update the input source for the component
-                    ControllerMode default_mode = ControllerMode::UNDEF;
-                    Device *d = std::get<1>(kv->second);
-                    if (d != nullptr) { // if there is no associated Device with this component then input handling is done in the main code
-                        default_mode = std::get<2>(kv->second); // preserve the stored default controller mode
-                        if (can_sim) { // if we just enabled simulatability...
-                            if (option == _pot_overload) { // ...and the pot is supposed to overload this component...
-                                    d->set_source(ControllerMode::POT); // ...then set the input source for the associated Device to read from the pot
-                            } else if (_enabled) { // ...and the pot isn't overloading this component, but the simulator is running...
-                                    d->set_source(ControllerMode::TOUCH); // ...then set the input source for the associated Device to read from the touchscreen
-                            }
-                        } else {
-                            d->set_source(default_mode); // we disabled simulation for this component, set it back to its default input source
-                        }
-                    }
-                    kv->second = simulable_t(can_sim, d, default_mode); // update the entry with the new simulatability status
-                }
-            } else {
-                _devices[option] = simulable_t(can_sim, nullptr, ControllerMode::UNDEF); // add a new entry with the simulatability status for this component
-            }
-        }
-
-        // set the component to be overridden by the pot (the pot can only override one component at a time)
-        void set_pot_overload(PotOption pot_option) { // we take a PotOption here so only valid components can be overridden
-            SimOption option = pot2sim(pot_option); // convert arg to the right type
-            if (option != _pot_overload) { // if we're overloading a different component, we need to reset the input source for the old one
-                auto kv = _devices.find(_pot_overload);
-                if (kv != _devices.end()) {
-                    Device *d = std::get<1>(kv->second);
-                    if (d != nullptr) { // if we were overloading a component with an associated Device...
-                        bool can_sim = std::get<0>(kv->second);
-                        if (_enabled && can_sim) { // ...and the simulator is on, and we're able to be simulated...
-                            d->set_source(ControllerMode::TOUCH); // ...then set the input source to the touchscreen
-                        } else { // ...and either the simulator is off or we aren't allowing simualtion for this component...
-                            ControllerMode default_mode = std::get<2>(kv->second);
-                            d->set_source(default_mode); // then set the input source for the component to its default
-                        }
-                    } // ...else this component is a boolean, and input source handling is done elsewhere
-                }
-                kv = _devices.find(option); // we need to set the input source of the newly-overridden component
-                if (kv != _devices.end()) {
-                    Device *d = std::get<1>(kv->second);
-                    if (d != nullptr) { // if  we're overloading a component with an associated devicie, we need to change the input source to the pot
-                        bool can_sim = std::get<0>(kv->second);
-                        if (can_sim) { // if we allow simualation for this componenent...
-                            d->set_source(ControllerMode::POT); // ...then set its input source to the pot
-                        }
-                    }
-                }
-                _pot_overload = option;
-            }
-        }
-
-        bool get_enabled() { return _enabled; }
-        SimOption get_pot_overload() { return _pot_overload; }
-};
-
 // class AnalogSensor are sensors where the value is based on an ADC reading (eg brake pressure, brake actuator position, pot)
 template<typename NATIVE_T, typename HUMAN_T>
 class AnalogSensor : public Sensor<NATIVE_T, HUMAN_T> {
   protected:
-    // NOTE: pot could be an actual Device as well...
-    std::shared_ptr<float> _pot_val; // to pull input from the pot if we're in simulation mode
+    virtual void handle_pin_mode() {
+        this->set_native(static_cast<NATIVE_T>(analogRead(this->_pin)));
+        this->ema(this->human.get()); // filtered values are kept in human format
+    }
+    virtual void handle_touch_mode() {
+        this->_val_filt.set(this->human.get());
+    }
+    virtual void handle_pot_mode() {
+        this->human.set(this->_pot->mapToRange(this->human.get_min(), this->human.get_max()));
+        this->_val_filt.set(this->human.get()); // don't filter the value we get from the pot, the pot output is already filtered
+    }
   public:
     AnalogSensor(uint8_t arg_pin) : Sensor<NATIVE_T, HUMAN_T>(arg_pin) {}
-    void read() {
-        switch (this->_source) {
-            case ControllerMode::PIN: 
-                this->set_native(analogRead(this->_pin));
-                this->ema(this->human.get()); // filtered values are kept in human format
-                break;
-            case ControllerMode::TOUCH:
-                this->_val_filt.set(this->human.get());
-                break;
-            case ControllerMode::POT:
-                this->human.set(map(*this->_pot_val, Potentiometer::percent_min, Potentiometer::percent_max, this->human.get_min(), this->human.get_max()));
-                this->_val_filt.set(this->human.get());
-                break;
-        } // take no action in other modes
-    }
-    void enable_pot_input(std::shared_ptr<float> pot_val_arg) {
-        this->set_can_source(ControllerMode::POT, true);
-        _pot_val = pot_val_arg;
-    }
 };
 
-// TODO: add description
+// PressureSensor represents a brake fluid pressure sensor.
+// It extends AnalogSensor to handle reading an analog pin
+// and converting the ADC value to a pressure value in PSI.
 class PressureSensor : public AnalogSensor<int32_t, float> {
-    protected:
-        // Multiplier and adder values to plug in for unit conversion math
-        float _m_factor;
-        float _b_offset;  
-        bool _invert;  // Flag to indicated if unit conversion math should multiply or divide
-
-        virtual float from_native(int32_t arg_val_native) {
-            float arg_val_f = static_cast<float>(arg_val_native);
-            float min_f = static_cast<float>(native.get_min());
-            float max_f = static_cast<float>(native.get_max());
-            float ret = -1;
-            if (!_invert) {
-                if (dir == TransducerDirection::REV) {
-                    ret = min_f + (max_f - (_b_offset + (_m_factor * arg_val_f)));
-                }
-                ret = _b_offset + (_m_factor * arg_val_f);
-            } else if (arg_val_f) { // NOTE: isn't 0.0 a valid value tho?
-                if (dir == TransducerDirection::REV) {
-                    ret = min_f + (max_f - (_b_offset + (_m_factor / arg_val_f)));
-                }
-                ret = _b_offset + (_m_factor / arg_val_f);
-            } else {
-                printf ("Error: unit conversion refused to divide by zero\n");
-                // NOTE: hmmmm, couldn't -1 be a valid value in some caes?
-            }
-            return ret;
-        }
-
-        virtual int32_t to_native(float arg_val_human) {
-            float arg_val_f = static_cast<float>(arg_val_human);
-            float min_f = static_cast<float>(human.get_min());
-            float max_f = static_cast<float>(human.get_max());
-            float ret = -1;
-            if (dir == TransducerDirection::REV) {
-                arg_val_f = min_f + (max_f - arg_val_f);
-            }
-            if (_invert && (arg_val_f - _b_offset)) {
-                ret = _m_factor / (arg_val_f - _b_offset);
-            } else if (!_invert && _m_factor) {
-                ret = (arg_val_f - _b_offset) / _m_factor;
-            } else {
-                printf ("Error: unit conversion refused to divide by zero\n");
-                // NOTE: hmmmm, couldn't -1 be a valid value in some caes?
-            }
-            return ret;
-        }
-
     public:
         // NOTE: for now lets keep all the config stuff here in the class. could also read in values from a config file at some point.
-        static constexpr int32_t min_adc_range = 0;
-        static constexpr int32_t max_adc_range = 4095;
         static constexpr int32_t min_adc = 658; // Sensor reading when brake fully released.  230430 measured 658 adc (0.554V) = no brakes
         static constexpr int32_t max_adc = 2080; // Sensor measured maximum reading. (ADC count 0-4095). 230430 measured 2080 adc (1.89V) is as hard as [wimp] chris can push
-
-        // 1000 psi * (adc_max v - v_min v) / ((4095 adc - 658 adc) * (v-max v - v-min v)) = 0.2 psi/adc 
-        static constexpr float initial_psi_per_adc = 1000.0 * (3.3 - 0.554) / ( (max_adc_range - min_adc) * (4.5 - 0.554) ); 
+        static constexpr float initial_psi_per_adc = 1000.0 * (3.3 - 0.554) / ( (adcrange_adc - min_adc) * (4.5 - 0.554) ); // 1000 psi * (adc_max v - v_min v) / ((4095 adc - 658 adc) * (v-max v - v-min v)) = 0.2 psi/adc 
         static constexpr float initial_ema_alpha = 0.1;
         static constexpr float initial_offset = 0.0;
         static constexpr bool initial_invert = false;
 
-        PressureSensor(uint8_t arg_pin, std::shared_ptr<float> pot_arg=nullptr) : AnalogSensor<int32_t, float>(arg_pin) {
+        PressureSensor(uint8_t arg_pin) : AnalogSensor<int32_t, float>(arg_pin) {
             _ema_alpha = initial_ema_alpha;
             _m_factor = initial_psi_per_adc;
             _b_offset = initial_offset;
@@ -704,9 +386,7 @@ class PressureSensor : public AnalogSensor<int32_t, float> {
             human.set_limits(from_native(native.get_min()), from_native(native.get_max()));
             set_native(min_adc);
             set_can_source(ControllerMode::PIN, true);
-            if (pot_arg) {
-                enable_pot_input(pot_arg);
-            }
+            set_can_source(ControllerMode::POT, true);
         }
         PressureSensor() = delete;
 
@@ -714,14 +394,55 @@ class PressureSensor : public AnalogSensor<int32_t, float> {
             set_pin(_pin, INPUT);
             set_source(ControllerMode::PIN);
         }
-    
-        // Convert units from base numerical value to disp units:  val_native = m-factor*val_numeric + offset  -or-  val_native = m-factor/val_numeric + offset  where m-factor, b-offset, invert are set here
-        void set_convert(float arg_m_factor, float arg_b_offset, bool arg_invert) {
-            _m_factor = arg_m_factor;
-            _b_offset = arg_b_offset;
-            _invert = arg_invert;
-            set_native(native.get());
+};
+
+// BrakePositionSensor represents a linear position sensor
+// for measuring brake position (TODO which position? pad? pedal?)
+// Extends AnalogSensor for handling analog pin reading and conversion.
+class BrakePositionSensor : public AnalogSensor<int32_t, float> {
+    protected:
+        // TODO: add description
+        float _zeropoint;
+        void handle_touch_mode() { _val_filt.set((nom_lim_retract_in + _zeropoint) / 2); } // To keep brake position in legal range during simulation
+    public:
+        // NOTE: for now lets keep all the config stuff here in the class. could also read in values from a config file at some point.
+        static constexpr float nom_lim_retract_in = 0.506;  // Retract limit during nominal operation. Brake motor is prevented from pushing past this. (in)
+        static constexpr float nom_lim_extend_in = 4.624;  // TUNED 230602 - Extend limit during nominal operation. Brake motor is prevented from pushing past this. (in)
+        static constexpr float abs_min_retract_in = 0.335;  // TUNED 230602 - Retract value corresponding with the absolute minimum retract actuator is capable of. ("in"sandths of an inch)
+        static constexpr float abs_max_extend_in = 8.300;  // TUNED 230602 - Extend value corresponding with the absolute max extension actuator is capable of. (in)
+        static constexpr float park_in = 4.234;  // TUNED 230602 - Best position to park the actuator out of the way so we can use the pedal (in)
+        static constexpr float margin_in = .029;  // TODO: add description
+        static constexpr float initial_in_per_adc = 3.3 * 10000.0 / (5.0 * adcrange_adc * 557); // 3.3 v * 10k ohm * 1/5 1/v * 1/4095 1/adc * 1/557 in/ohm = 0.0029 in/adc
+        static constexpr float initial_zeropoint_in = 3.179;  // TUNED 230602 - Brake position value corresponding to the point where fluid PSI hits zero (in)
+        static constexpr float initial_ema_alpha = 0.25;
+        static constexpr float initial_offset = 0.0;
+        static constexpr bool initial_invert = false;
+
+        BrakePositionSensor(uint8_t arg_pin) : AnalogSensor<int32_t, float>(arg_pin) {
+            _ema_alpha = initial_ema_alpha;
+            _m_factor = initial_in_per_adc;
+            _b_offset = initial_offset;
+            _invert = initial_invert;
+            _zeropoint = initial_zeropoint_in;
+            human.set_limits(nom_lim_retract_in, nom_lim_extend_in);
+            native.set_limits(to_native(human.get_min()), to_native(human.get_max()));
+            set_can_source(ControllerMode::PIN, true);
+            set_can_source(ControllerMode::POT, true);
         }
+        BrakePositionSensor() = delete;
+
+        void setup() {
+            set_pin(_pin, INPUT);
+            set_source(ControllerMode::PIN);
+        }
+        
+        // is tha brake motor parked?
+        bool parked() { return abs(_val_filt.get() - park_in) <= margin_in; }
+
+        float get_park_position() { return park_in; }
+        float get_margin() { return margin_in; }
+        float get_zeropoint() { return _zeropoint; }
+        void set_zeropoint(float zeropoint_arg) { _zeropoint = zeropoint_arg; }
 };
 
 class HotrcManager {
@@ -1003,5 +724,190 @@ class OutToggle : public Toggle {
 // };
 // class Settings {
 // };
+
+// NOTE: if devices.h gets to be too long, we can (and maybe just should) move this to a separate file, it's not really a device...
+
+// This enum class represent the components which can be simulated (SimOption). It's a uint8_t type under the covers, so it can be used as an index
+typedef uint8_t opt_t;
+enum class SimOption : opt_t { none=0, pressure, brkpos, tach, airflow, speedo, battery, coolant, joy, basicsw, cruisesw, syspower, starter, ignition };
+
+// Simulator manages the ControllerMode handling logic for all simulatable components. Currently, components can recieve simulated input from either the touchscreen, or from
+// NOTE: this class is designed to be backwards-compatible with existing code, which does everything with global booleans. if/when we switch all our Devices to use ControllerModes,
+//       we can simplify the logic here a lot.
+class Simulator {
+    private:
+        // NOTE: if we only simulated devices, we could keep track of simulability in the Device class. We could keep the default ControllerMode in Device the same way.
+        // 3-tuple for a given component, keeping track of simulability status (whether this component is allowed to be simulated), an associated Device (a pointer to the actual component),
+        // and a default ControllerMode (the mode we would like the component to switch back to when it stops being simulated)
+        typedef std::tuple<bool, Device*, ControllerMode> simulable_t;
+        std::map<SimOption, simulable_t> _devices; // a collection of simulatable components
+        bool _enabled = false; // keep track of whether the simulator is running or not
+        SimOption _pot_overload; // keep track of which component is getting info from the pot
+
+        Potentiometer& _pot;
+    public:
+        static constexpr SimOption initial_pot_overload = SimOption::speedo;
+        
+        // initial simulation settings
+        static constexpr bool initial_sim_joy = false;
+        static constexpr bool initial_sim_tach = true;
+        static constexpr bool initial_sim_speedo = true;
+        static constexpr bool initial_sim_brkpos = true;
+        static constexpr bool initial_sim_basicsw = true;
+        static constexpr bool initial_sim_cruisesw = false;
+        static constexpr bool initial_sim_pressure = true;
+        static constexpr bool initial_sim_syspower = true;
+        static constexpr bool initial_sim_starter = true;
+        static constexpr bool initial_sim_ignition = true;
+        static constexpr bool initial_sim_airflow = false;
+        static constexpr bool initial_sim_battery = true;
+        static constexpr bool initial_sim_coolant = true;
+
+        Simulator(Potentiometer& pot_arg, SimOption overload_arg=SimOption::none) : _pot(pot_arg) {
+            // set initial simulatability status for all components
+            set_can_simulate(SimOption::joy, initial_sim_joy);
+            set_can_simulate(SimOption::tach, initial_sim_tach);
+            set_can_simulate(SimOption::speedo, initial_sim_speedo);
+            set_can_simulate(SimOption::brkpos, initial_sim_brkpos);
+            set_can_simulate(SimOption::basicsw, initial_sim_basicsw);
+            set_can_simulate(SimOption::cruisesw, initial_sim_cruisesw);
+            set_can_simulate(SimOption::pressure, initial_sim_pressure);
+            set_can_simulate(SimOption::syspower, initial_sim_syspower);
+            set_can_simulate(SimOption::starter, initial_sim_starter);
+            set_can_simulate(SimOption::ignition, initial_sim_ignition);
+            set_can_simulate(SimOption::airflow, initial_sim_airflow);
+            set_can_simulate(SimOption::battery, initial_sim_battery);
+            set_can_simulate(SimOption::coolant, initial_sim_coolant);
+            set_pot_overload(overload_arg); // set initial pot overload
+        }
+
+        // turn on the simulator. all components which are set to be simulated will switch to simulated input
+        void enable() {
+            if (!_enabled) {
+                for ( auto &kv : _devices ) { // go through all our components
+                    bool can_sim = std::get<0>(kv.second); // check simulatability status
+                    if (can_sim && _pot_overload != kv.first) { // if component has simulation enabled and it's not being overloaded by the pot...
+                        Device *d = std::get<1>(kv.second);
+                        // NOTE: the nullptr checks here and below exist so that we can work with boolean components as well as Devices, for backwards compatability
+                        if (d != nullptr) {
+                           d->set_source(ControllerMode::TOUCH); // ...then set component to take input from the touchscreen
+                        }
+                    }
+                }
+                _enabled = true;
+            }
+        }
+
+        // turn off the simulator. all devices will be set to their default input (if they are not being overloaded by the pot)
+        void disable() {
+            if (_enabled) {
+                for ( auto &kv : _devices ) { // go through all our components
+                    bool can_sim = std::get<0>(kv.second);
+                    if (can_sim && _pot_overload != kv.first) { // if component has simulation enabled and it's not being overloaded by the pot...
+                        Device *d = std::get<1>(kv.second);
+                        if (d != nullptr) {
+                            ControllerMode default_mode = std::get<2>(kv.second);
+                            d->set_source(default_mode); // ...then it's in simulation mode and needs to be set back to it's default mode, since we are no longer simulating
+                        }
+                    }
+                }
+                _enabled = false;
+            }
+        }
+
+        // toggle the simulator on and off
+        void toggle() {
+            return _enabled ? disable() : enable();
+        }
+
+        // check if a componenet is currently being simulated (by either the touchscreen or the pot)
+        bool simulating(SimOption option) {
+            return can_simulate(option) && (_enabled || _pot_overload == option);
+        }
+
+        // associate a Device and a given fall-back ControllerMode with a SimOption
+        void register_device(SimOption option, Device &d, ControllerMode default_mode) {
+            bool can_sim = false; // by default, disable simulation for this component
+            auto kv = _devices.find(option); // look for the component
+            if (kv != _devices.end()) {
+                can_sim = std::get<0>(kv->second); // if an entry for the component already existed, preserve its simulatability status
+            }
+            d.set_pot_input(_pot);
+            _devices[option] = simulable_t(can_sim, &d, default_mode); // store info for this component
+        }
+
+        // check if a component can be simulated (by either the touchscreen or the pot)
+        bool can_simulate(SimOption option) {
+            auto kv = _devices.find(option); // look for the component
+            if (kv != _devices.end()) {
+                return std::get<0>(kv->second); // if it exists, check the simulability status
+            }
+            return false; // couldn't find component, so there's no way we can simulate it
+        }
+
+        // set simulatability status for a component
+        void set_can_simulate(SimOption option, bool can_sim) {
+            auto kv = _devices.find(option); // look for component
+            if (kv != _devices.end()) { // if an entry for this component already exists, check if the new simulatability status is different from the old
+                bool old_can_sim = std::get<0>(kv->second);
+                if (can_sim != old_can_sim) { // if the simulation status has changed, we need to update the input source for the component
+                    ControllerMode default_mode = ControllerMode::UNDEF;
+                    Device *d = std::get<1>(kv->second);
+                    if (d != nullptr) { // if there is no associated Device with this component then input handling is done in the main code
+                        default_mode = std::get<2>(kv->second); // preserve the stored default controller mode
+                        if (can_sim) { // if we just enabled simulatability...
+                            if (option == _pot_overload) { // ...and the pot is supposed to overload this component...
+                                    d->set_source(ControllerMode::POT); // ...then set the input source for the associated Device to read from the pot
+                            } else if (_enabled) { // ...and the pot isn't overloading this component, but the simulator is running...
+                                    d->set_source(ControllerMode::TOUCH); // ...then set the input source for the associated Device to read from the touchscreen
+                            }
+                        } else {
+                            d->set_source(default_mode); // we disabled simulation for this component, set it back to its default input source
+                        }
+                    }
+                    kv->second = simulable_t(can_sim, d, default_mode); // update the entry with the new simulatability status
+                }
+            } else {
+                _devices[option] = simulable_t(can_sim, nullptr, ControllerMode::UNDEF); // add a new entry with the simulatability status for this component
+            }
+        }
+
+        // set the component to be overridden by the pot (the pot can only override one component at a time)
+        void set_pot_overload(SimOption option) {
+            if (option != _pot_overload) { // if we're overloading a different component, we need to reset the input source for the old one
+                auto kv = _devices.find(_pot_overload);
+                if (kv != _devices.end()) {
+                    Device *d = std::get<1>(kv->second);
+                    if (d != nullptr) { // if we were overloading a component with an associated Device...
+                        bool can_sim = std::get<0>(kv->second);
+                        if (_enabled && can_sim) { // ...and the simulator is on, and we're able to be simulated...
+                            d->set_source(ControllerMode::TOUCH); // ...then set the input source to the touchscreen
+                        } else { // ...and either the simulator is off or we aren't allowing simualtion for this component...
+                            ControllerMode default_mode = std::get<2>(kv->second);
+                            d->set_source(default_mode); // then set the input source for the component to its default
+                        }
+                    } // ...else this component is a boolean, and input source handling is done elsewhere
+                }
+                kv = _devices.find(option); // we need to set the input source of the newly-overridden component
+                if (kv != _devices.end()) {
+                    Device *d = std::get<1>(kv->second);
+                    if (d != nullptr ) { // if  we're overloading a component with an associated device, we need to change the input source to the pot
+                        if (d->can_source(ControllerMode::POT)) { // ...and we're allowed to overload this component...
+                            bool can_sim = std::get<0>(kv->second);
+                            if (can_sim) { // if we allow simualation for this componenent...
+                                d->set_source(ControllerMode::POT); // ...then set its input source to the pot
+                            }
+                        } else {
+                            printf("invalid pot overload selected: %d/n", option);
+                        }
+                    }
+                }
+                _pot_overload = option;
+            }
+        }
+
+        bool get_enabled() { return _enabled; }
+        SimOption get_pot_overload() { return _pot_overload; }
+};
 
 #endif  // CLASSES_H

--- a/CANTroller2/src/display.h
+++ b/CANTroller2/src/display.h
@@ -65,7 +65,7 @@ char pagecard[8][5] = { "Run ", "Joy ", "Car ", "PWMs", "Bpid", "Gpid", "Cpid", 
 char modecard[7][7] = { "Basic", "Shutdn", "Stall", "Hold", "Fly", "Cruise", "Cal" };
 int32_t colorcard[arraysize(modecard)] = { MGT, RED, ORG, YEL, GRN, TEAL, MBLU };
 enum dataset_pages { PG_RUN, PG_JOY, PG_CAR, PG_PWMS, PG_BPID, PG_GPID, PG_CPID, PG_TEMP };
-char sensorcard[8][7] = { "bkpres", "brkpos", "tach", "airflw", "speedo", "batt", "engtmp", "none" };
+char sensorcard[8][7] = { "none", "bkpres", "brkpos", "tach", "airflw", "speedo", "batt", "engtmp" };
 
 char telemetry[disp_fixed_lines][9] = {  
     "CtrlVert",
@@ -649,9 +649,9 @@ class Display {
                 draw_dynamic(8, steer_out_percent, steer_left_percent, steer_right_percent);
                 if (dataset_page == PG_RUN) {
                     draw_dynamic(9, airflow_filt_mph, airflow_min_mph, airflow_max_mph);
-                    draw_dynamic(10, brake_pos_filt_in, brake_pos_nom_lim_retract_in, brake_pos_nom_lim_extend_in);
+                    draw_dynamic(10, brkpos_sensor.get_filtered_value(), BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);
                     draw_dynamic(11, battery_filt_v, 0.0, battery_max_v);
-                    draw_dynamic(12, pot.get_filtered_value(), pot.get_min_human(), pot.get_max_human());
+                    draw_dynamic(12, pot.get(), pot.min(), pot.max());
                     draw_truth(13, simulator.can_simulate(SimOption::joy), 0);
                     draw_truth(14, simulator.can_simulate(SimOption::pressure), 0);
                     draw_truth(15, simulator.can_simulate(SimOption::brkpos), 0);
@@ -684,7 +684,7 @@ class Display {
                     draw_dynamic(16, airflow_max_mph, 0.0, airflow_abs_max_mph);
                     draw_dynamic(17, speedo_idle_mph, 0.0, speedo_redline_mph);
                     draw_dynamic(18, speedo_redline_mph, 0.0, speedo_max_mph);
-                    draw_dynamic(19, brake_pos_zeropoint_in, brake_pos_nom_lim_retract_in, brake_pos_nom_lim_extend_in);
+                    draw_dynamic(19, brkpos_sensor.get_zeropoint(), BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);
                 }
                 else if (dataset_page == PG_PWMS) {
                     draw_dynamic(9, brake_pulse_out_us, brake_pulse_retract_us, brake_pulse_extend_us);

--- a/CANTroller2/src/utils.h
+++ b/CANTroller2/src/utils.h
@@ -11,7 +11,36 @@
 #define adcrange_adc 4095  // = 2^adcbits-1
 #define adcmidscale_adc 2047  // = 2^(adcbits-1)-1
 
-// pin operations that first check if pin exists for the current board
+/* Utility Functions */
+#define arraysize(x) ((int32_t)(sizeof(x) / sizeof((x)[0])))  // A macro function to determine the length of string arrays
+#define floor(amt, lim) ((amt <= lim) ? lim : amt)
+#define ceiling(amt, lim) ((amt >= lim) ? lim : amt)
+
+// TODO: check to see if these are different from the builtins, if not then we shouldn't bother redefining them
+#undef max
+inline float max (float a, float b) { return (a > b) ? a : b; }
+inline int32_t max (int32_t a, int32_t b) { return (a > b) ? a : b; }
+
+#undef min
+inline float min (float a, float b) { return (a < b) ? a : b; }
+inline int32_t min (int32_t a, int32_t b) { return (a < b) ? a : b; }
+
+#undef constrain
+inline float constrain (float amt, float low, float high) { return (amt < low) ? low : ((amt > high) ? high : amt); }
+inline int32_t constrain (int32_t amt, int32_t low, int32_t high) { return (amt < low) ? low : ((amt > high) ? high : amt); }
+inline uint32_t constrain (uint32_t amt, uint32_t low, uint32_t high) { return (amt < low) ? low : ((amt > high) ? high : amt); }
+
+#undef map
+inline float map(float x, float in_min, float in_max, float out_min, float out_max) {
+    if (in_max - in_min) return out_min + (x - in_min) * (out_max - out_min) / (in_max - in_min);
+    return out_max;  // Instead of dividing by zero, return the highest valid result
+}
+inline int32_t map(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max) {
+    if (in_max - in_min) return out_min + (x - in_min) * (out_max - out_min) / (in_max - in_min);
+    return out_max;  // Instead of dividing by zero, return the highest valid result
+}
+
+/* Pin Operations */
 void set_pin(int32_t pin, int32_t mode) { if (pin >= 0 && pin != 255) pinMode (pin, mode); }
 void write_pin(int32_t pin, int32_t val) {  if (pin >= 0 && pin != 255) digitalWrite (pin, val); }
 int32_t read_pin(int32_t pin) { return (pin >= 0 && pin != 255) ? digitalRead (pin) : -1; }
@@ -23,16 +52,19 @@ float convert_units(float from_units, float convert_factor, bool invert, float i
     return -1;
 }
 
-#undef map
-inline float map(float x, float in_min, float in_max, float out_min, float out_max) {
-    if (in_max - in_min) return out_min + (x - in_min) * (out_max - out_min) / (in_max - in_min);
-    return out_max;  // Instead of dividing by zero, return the highest valid result
+// Exponential Moving Average filter : Smooth out noise on inputs. 0 < alpha < 1 where lower = smoother and higher = more responsive
+// Pass in a fresh raw value, address of filtered value, and alpha factor, filtered value will get updated
+float ema_filt(float raw, float filt, float alpha) {
+    return (alpha * raw) + ((1 - alpha) * filt);
 }
-inline int32_t map(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max) {
-    if (in_max - in_min) return out_min + (x - in_min) * (out_max - out_min) / (in_max - in_min);
-    return out_max;  // Instead of dividing by zero, return the highest valid result
+template<typename RAW_T, typename FILT_T>
+void ema_filt(RAW_T raw, FILT_T* filt, float alpha) {
+    float raw_f = static_cast<float>(raw);
+    float filt_f = static_cast<float>(*filt);
+    *filt = static_cast<FILT_T>(ema_filt(raw_f, filt_f, alpha));
 }
-class Timer {  // 32 bit microsecond timer overflows after 71.5 minutes
+
+class Timer {  // 32 bit microsecond timer overflows after 71.5 minutes, so we use 64 bits
   protected:
     // TODO: should check whether these actually use larger types (often compilers will just use their largest word)
     volatile int64_t start_us = 0;


### PR DESCRIPTION
Create a BrakePositionSensor class and use it in place of the existing brkpos code. This change got me thinking about some of the design decisions we've made, and it includes a few changes which I think are warranted:

- move Potentiometer to uictrl.h. The pot is really mmore of a user-input than a sensor, and even though it worked as a child of Device it doesn't really need to be (it doesn't take a source, for example). It's cleaner to have it be separate, and the code for it is actually simpler.

- make the existing linear conversion code the default for Trasnducer (as we had it originally). It's easy to override it if needed, and this way we don't have to copy it everywhere. There's probably a better way to do this but I think we'll need to convert some more components before we worry about it more.

- move the controller source handling logic to Device, in a new function called update(). Different modes are handled with handle_MODE() calls which do nothing by default but can be overridden in child classes as needed. This change makes sense, since Device is already where we're handling source stuff.

- move the ema_filt() algo (and some other util functions) to utils.h. The new Potentiometer implementation needs to call ema_filt() (since it's not using the one built into Sensor). I rewrote ema_filt() to have two versions, one that takes raw values and another that takes a pointer to a value to be updated. I temmplated the second one, so you can use it with any numeric type and it should work (the template is based off the args, so you don't even need to define any templates when you call it).

- move Simulator code to bottom of file. Really, it should probably go in a different file if Devices.h gets much bigger, but for now it's enough just to be out of the way.