### PR TITLE
Implement BatterySensor and AirflowSensor

### DIFF
--- a/CANTroller2/src/cantroller2.cpp
+++ b/CANTroller2/src/cantroller2.cpp
@@ -111,18 +111,14 @@ void setup() {  // Setup just configures pins (and detects touchscreen type)
     printf ("Init i2c and i2c-enabled devices..");
     i2c.init();
     airflow_sensor.setup(); // must be done after i2c is started
-    map_detected = i2c.device_detected(0x18);
-    printf ("MAP sensor.. %sdetected\n", (map_detected) ? "" : "not ");
-    if (map_detected) {
-        if (map_sensor.begin() == false) printf ("  Sensor not responding");  // Begin communication with air flow sensor) over I2C 
-        else printf ("  Reading %f atm manifold pressure\n", map_sensor.readPressure(ATM));
-    }
+    map_sensor.setup();
 
     printf("Simulator setup..\n");
     simulator.register_device(SimOption::pressure, pressure_sensor, pressure_sensor.source());
     simulator.register_device(SimOption::brkpos, brkpos_sensor, brkpos_sensor.source());
     simulator.register_device(SimOption::battery, battery_sensor, battery_sensor.source());
     simulator.register_device(SimOption::airflow, airflow_sensor, airflow_sensor.source());
+    simulator.register_device(SimOption::mapsens, map_sensor, map_sensor.source());
     simulator.register_device(SimOption::tach, tachometer, tachometer.source());
     simulator.register_device(SimOption::speedo, speedometer, speedometer.source());
 
@@ -224,11 +220,8 @@ void loop() {
     airflow_sensor.update();
 
     // MAP sensor
-    if (simulator.can_simulate(SimOption::mapsens) && simulator.get_pot_overload() == SimOption::mapsens) map_filt_psi = pot.mapToRange(map_min_psi, map_max_psi);
-    else if (map_detected && !simulator.simulating(SimOption::mapsens)) {
-        map_psi = map_sensor.readPressure(PSI);
-        ema_filt (map_psi, &map_filt_psi, map_ema_alpha);  // Sensor EMA filter
-    }
+    map_sensor.update();
+
     // Speedo - takes 14 us to read when no activity
     speedometer.update();
 
@@ -506,8 +499,8 @@ void loop() {
             else if (selected_value == 3) adj = adj_val (&tach_idle_cold_max_rpm, 0.1*(float)sim_edit_delta, tach_idle_hot_min_rpm + 1, tach_idle_abs_max_rpm);
             else if (selected_value == 4) adj = adj_val (tachometer.get_redline_rpm_ptr().get(), 0.1*(float)sim_edit_delta, throttle.get_idlehigh(), tachometer.get_max_rpm());
             else if (selected_value == 5) adj_val (airflow_sensor.get_max_mph_ptr().get(), 0.01*(float)sim_edit_delta, 0, airflow_sensor.get_abs_max_mph());
-            else if (selected_value == 6) adj_val (&map_min_psi, 0.1*(float)sim_edit_delta, map_abs_min_psi, map_abs_max_psi);
-            else if (selected_value == 6) adj_val (&map_max_psi, 0.1*(float)sim_edit_delta, map_abs_min_psi, map_abs_max_psi);
+            else if (selected_value == 6) adj_val (map_sensor.get_min_psi_ptr().get(), 0.1*(float)sim_edit_delta, map_sensor.get_abs_min_psi(), map_sensor.get_abs_max_psi());
+            else if (selected_value == 6) adj_val (map_sensor.get_max_psi_ptr().get(), 0.1*(float)sim_edit_delta, map_sensor.get_abs_min_psi(), map_sensor.get_abs_max_psi());
             else if (selected_value == 8) adj_val (&speedo_idle_mph, 0.01*(float)sim_edit_delta, 0, speedometer.get_redline_mph() - 1);
             else if (selected_value == 9) adj_val (speedometer.get_redline_mph_ptr().get(), 0.01*(float)sim_edit_delta, speedo_idle_mph, 30);
             else if (selected_value == 10) adj_val (brkpos_sensor.get_zeropoint_ptr().get(), 0.001*(float)sim_edit_delta, BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);

--- a/CANTroller2/src/devices.h
+++ b/CANTroller2/src/devices.h
@@ -7,11 +7,16 @@
 #include <map>
 #include <tuple>
 #include <memory> // for std::shared_ptr
+#include <SparkFun_FS3000_Arduino_Library.h>  // For airflow sensor  http://librarymanager/All#SparkFun_FS3000
 #include "Arduino.h"
 #include "FunctionalInterrupt.h"
 #include "utils.h"
 #include "uictrl.h"
 // #include "xtensa/core-macros.h"  // access to ccount register for esp32 timing ticks
+
+// NOTE: the following classes all contain their own initial config values (for simplicity). We could instead use Config objects and pass them in at construction time, which might be
+//       a little cleaner organization-wise, since all the configs would be consolidated. It would also allow us to read Configs from storage somewhere, so we could have persistent
+//       calibration.
 
 // Param is a value which is constrained between min/max limits, representing a "raw" (aka unfiltered) quantity. A value with tight limits
 // (wehere min=val=max) is constant and cannot be changed without changing the limits. An unconstrained value can be represented by setting
@@ -185,7 +190,7 @@ class Device {
         }
     }
 
-    void set_pot_input(Potentiometer &pot_arg) {
+    void attach_pot(Potentiometer &pot_arg) {
         _pot = &pot_arg;
     }
 
@@ -204,8 +209,8 @@ template<typename NATIVE_T, typename HUMAN_T>
 class Transducer : public Device {
   protected:
     // Multiplier and adder values to plug in for unit conversion math
-    float _m_factor;
-    float _b_offset;  
+    float _m_factor = 1.0;
+    float _b_offset = 0.0;  
     bool _invert = false;  // Flag to indicated if unit conversion math should multiply or divide
     TransducerDirection dir = TransducerDirection::FWD; // NOTE: what is this for, exactly?
     
@@ -392,6 +397,69 @@ class Sensor : public Transducer<NATIVE_T, HUMAN_T> {
     std::shared_ptr<HUMAN_T> get_filtered_value_ptr() { return _val_filt.get_ptr(); } // NOTE: should just be public?
 };
 
+// AirflowSensor measures the air intake into the engine (i think?). It communicates with the external sensor using i2c.
+// NOTE: this is a strange type of Sensor, it's not really a Transducer but it does do filtering. maybe we should rethink the hierarchy a little?
+//       I think we can move Param to utils.h and add a class ExponentialMovingAverage there as well that just has the ema functionality, then make
+//       AirflowSensor a child of -> Device, ExponentialMovingAverage and not a Sensor at all. Would probably have a base class I2CSensor or something.
+class AirflowSensor : public Sensor<float,float> {
+    protected:
+        // NOTE: would all AirflowSensors have the same address? how does this get determined?
+        static constexpr uint8_t _i2c_address = 0x28;
+        static constexpr float _min_mph = 0.0;
+        static constexpr float _abs_max_mph = 33.55; // What diameter intake hose will reduce airspeed to abs max?  2.7 times the xsectional area. Current area is 6.38 cm2. New diameter = 4.68 cm (min). So, need to adapt to 2.5in + tube
+        static constexpr float _initial_max_mph = 33.5;  // 620/2 cm3/rot * 5000 rot/min (max) * 60 min/hr * 1/(pi * (2.85 / 2)^2) 1/cm2 * 1/160934 mi/cm = 90.58 mi/hr (mph) (?!)
+        static constexpr float _initial_airflow_mph = 0.0;
+        static constexpr float _ema_alpha = 0.2;
+
+        bool _detected = false;
+        FS3000 _sensor;
+        I2C &_i2c;
+
+        virtual void handle_pin_mode() {
+            this->set_native(_sensor.readMilesPerHour()); // note, this returns a float from 0-33.55 for the FS3000-1015 
+            calculate_ema();  // Sensor EMA filter
+        }
+
+        virtual void handle_pot_mode() {
+            this->human.set(this->_pot->mapToRange(this->human.get_min(), this->human.get_max()));
+            this->_val_filt.set(this->human.get()); // don't filter the value we get from the pot, the pot output is already filtered
+        }
+    
+        virtual void handle_set_human_limits() {
+            native.set_limits(human.get_min_ptr(), human.get_max_ptr());
+            _val_filt.set_limits(human.get_min_ptr(), human.get_max_ptr());
+        }
+    public:
+        AirflowSensor(I2C &i2c_arg) : Sensor<float,float>(-1), _i2c(i2c_arg) { // uses i2c instead of a pin, but it's still a Device...
+            human.set_limits(_min_mph, _initial_max_mph);
+            handle_set_human_limits();
+            set_can_source(ControllerMode::PIN, true);
+            set_can_source(ControllerMode::POT, true);
+        }
+        AirflowSensor() = delete;
+
+        void setup() {
+            bool airflow_detected = _i2c.device_detected(_i2c_address);
+            printf("Airflow sensor.. %sdetected", airflow_detected ? "" : "not ");
+            if (airflow_detected) {
+                if (_sensor.begin() == false) {
+                    printf("  Sensor not responding");  // Begin communication with air flow sensor) over I2C 
+                    set_source(ControllerMode::FIXED); // sensor is detected but not working, leave it in an error state ('fixed' as in not changing)
+                }
+                _sensor.setRange(AIRFLOW_RANGE_15_MPS);
+                printf ("  Sensor responding properly\n");
+                set_source(ControllerMode::PIN); // we aren't actually reading from a pin but the point is the same...
+            } else {
+                set_source(ControllerMode::UNDEF); // don't even have a device at all...
+            }
+        }
+
+        float get_min_mph() { return human.get_min(); }
+        float get_max_mph() { return human.get_max(); }
+        float get_abs_max_mph() { return _abs_max_mph; }
+        std::shared_ptr<float> get_max_mph_ptr() { return human.get_max_ptr(); }
+};
+
 // class AnalogSensor are sensors where the value is based on an ADC reading (eg brake pressure, brake actuator position, pot)
 template<typename NATIVE_T, typename HUMAN_T>
 class AnalogSensor : public Sensor<NATIVE_T, HUMAN_T> {
@@ -412,10 +480,9 @@ class AnalogSensor : public Sensor<NATIVE_T, HUMAN_T> {
 // BatterySensor reads the voltage level from the Mule battery
 class BatterySensor : public AnalogSensor<int32_t, float> {
     protected:
-        // NOTE: for now lets keep all the config stuff here in the class. could also read in values from a config file at some point.
         static constexpr float _initial_adc = adcmidscale_adc;
         static constexpr float _initial_v = 10.0;
-        static constexpr float _min_v = 0.0; // NOTE: this would be if the battery is totally dead...? (not that we'd be able to run this code anyway...)
+        static constexpr float _min_v = 0.0; // The min vehicle voltage we can sense.
         static constexpr float _max_v = 16.0;  // The max vehicle voltage we can sense. Design resistor divider to match. Must exceed max V possible.
         static constexpr float _initial_v_per_adc = _max_v / adcrange_adc;
         static constexpr float _initial_ema_alpha = 0.01;  // alpha value for ema filtering, lower is more continuous, higher is more responsive (0-1). 
@@ -438,7 +505,6 @@ class BatterySensor : public AnalogSensor<int32_t, float> {
 // and converting the ADC value to a pressure value in PSI.
 class PressureSensor : public AnalogSensor<int32_t, float> {
     public:
-        // NOTE: for now lets keep all the config stuff here in the class. could also read in values from a config file at some point.
         static constexpr int32_t min_adc = 658; // Sensor reading when brake fully released.  230430 measured 658 adc (0.554V) = no brakes
         static constexpr int32_t max_adc = 2080; // Sensor measured maximum reading. (ADC count 0-4095). 230430 measured 2080 adc (1.89V) is as hard as [wimp] chris can push
         static constexpr float initial_psi_per_adc = 1000.0 * (3.3 - 0.554) / ( (adcrange_adc - min_adc) * (4.5 - 0.554) ); // 1000 psi * (adc_max v - v_min v) / ((4095 adc - 658 adc) * (v-max v - v-min v)) = 0.2 psi/adc 
@@ -469,7 +535,6 @@ class BrakePositionSensor : public AnalogSensor<int32_t, float> {
         std::shared_ptr<float> _zeropoint;
         void handle_touch_mode() { _val_filt.set((nom_lim_retract_in + *_zeropoint) / 2); } // To keep brake position in legal range during simulation
     public:
-        // NOTE: for now lets keep all the config stuff here in the class. could also read in values from a config file at some point.
         static constexpr float nom_lim_retract_in = 0.506;  // Retract limit during nominal operation. Brake motor is prevented from pushing past this. (in)
         static constexpr float nom_lim_extend_in = 4.624;  // TUNED 230602 - Extend limit during nominal operation. Brake motor is prevented from pushing past this. (in)
         static constexpr float abs_min_retract_in = 0.335;  // TUNED 230602 - Retract value corresponding with the absolute minimum retract actuator is capable of. ("in"sandths of an inch)
@@ -1011,8 +1076,17 @@ class Simulator {
             auto kv = _devices.find(option); // look for the component
             if (kv != _devices.end()) {
                 can_sim = std::get<0>(kv->second); // if an entry for the component already existed, preserve its simulatability status
+                if (can_sim) { // if simulability has already been enabled...
+                    if (option == _pot_overload) { // ...and the pot is supposed to overload this component...
+                        d.set_source(ControllerMode::POT); // ...then set the input source for the associated Device to read from the pot
+                    } else if (_enabled) { // ...and the pot isn't overloading this component, but the simulator is running...
+                        d.set_source(ControllerMode::TOUCH); // ...then set the input source for the associated Device to read from the touchscreen
+                    }
+                }
             }
-            d.set_pot_input(_pot);
+            if (d.can_source(ControllerMode::POT)) {
+                d.attach_pot(_pot); // if this device can be overloaded by the pot, connect it to pot input
+            }
             _devices[option] = simulable_t(can_sim, &d, default_mode); // store info for this component
         }
 

--- a/CANTroller2/src/display.h
+++ b/CANTroller2/src/display.h
@@ -612,7 +612,7 @@ class Display {
                     draw_dynamic(9, brkpos_sensor.get_filtered_value(), BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);
                     draw_dynamic(10, airflow_filt_mph, airflow_min_mph, airflow_max_mph);
                     draw_dynamic(11, map_filt_psi, map_min_psi, map_max_psi);
-                    draw_dynamic(12, battery_filt_v, 0.0, battery_max_v);
+                    draw_dynamic(11, battery_sensor.get_filtered_value(), battery_sensor.get_min_v(), battery_sensor.get_max_v());
                     draw_dynamic(13, pot.get(), pot.min(), pot.max());
                     draw_truth(14, starter, 0);
                     draw_eraseval(15);

--- a/CANTroller2/src/display.h
+++ b/CANTroller2/src/display.h
@@ -611,7 +611,7 @@ class Display {
                 if (dataset_page == PG_RUN) {
                     draw_dynamic(9, brkpos_sensor.get_filtered_value(), BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);
                     draw_dynamic(10, airflow_sensor.get_filtered_value(), airflow_sensor.get_min_mph(), airflow_sensor.get_max_mph());
-                    draw_dynamic(11, map_filt_psi, map_min_psi, map_max_psi);
+                    draw_dynamic(11, map_sensor.get_filtered_value(), map_sensor.get_min_psi(), map_sensor.get_max_psi());
                     draw_dynamic(12, battery_sensor.get_filtered_value(), battery_sensor.get_min_v(), battery_sensor.get_max_v());
                     draw_dynamic(13, pot.get(), pot.min(), pot.max());
                     draw_truth(14, starter, 0);
@@ -641,8 +641,8 @@ class Display {
                     draw_eraseval(12);
                     draw_eraseval(13);
                     draw_dynamic(14, airflow_sensor.get_max_mph(), 0.0, airflow_sensor.get_abs_max_mph());
-                    draw_dynamic(15, map_min_psi, map_abs_min_psi, map_abs_max_psi);
-                    draw_dynamic(16, map_max_psi, map_abs_min_psi, map_abs_max_psi);
+                    draw_dynamic(15, map_sensor.get_min_psi(), map_sensor.get_abs_min_psi(), map_sensor.get_abs_max_psi());
+                    draw_dynamic(16, map_sensor.get_max_psi(), map_sensor.get_abs_min_psi(), map_sensor.get_abs_max_psi());
                     draw_dynamic(17, speedo_idle_mph, 0.0, speedometer.get_redline_mph());
                     draw_dynamic(18, speedometer.get_redline_mph(), 0.0, speedometer.get_max_human());
                     draw_dynamic(19, brkpos_sensor.get_zeropoint(), BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);

--- a/CANTroller2/src/display.h
+++ b/CANTroller2/src/display.h
@@ -610,9 +610,9 @@ class Display {
                 draw_dynamic(8, steer_out_percent, steer_left_percent, steer_right_percent);
                 if (dataset_page == PG_RUN) {
                     draw_dynamic(9, brkpos_sensor.get_filtered_value(), BrakePositionSensor::nom_lim_retract_in, BrakePositionSensor::nom_lim_extend_in);
-                    draw_dynamic(10, airflow_filt_mph, airflow_min_mph, airflow_max_mph);
+                    draw_dynamic(10, airflow_sensor.get_filtered_value(), airflow_sensor.get_min_mph(), airflow_sensor.get_max_mph());
                     draw_dynamic(11, map_filt_psi, map_min_psi, map_max_psi);
-                    draw_dynamic(11, battery_sensor.get_filtered_value(), battery_sensor.get_min_v(), battery_sensor.get_max_v());
+                    draw_dynamic(12, battery_sensor.get_filtered_value(), battery_sensor.get_min_v(), battery_sensor.get_max_v());
                     draw_dynamic(13, pot.get(), pot.min(), pot.max());
                     draw_truth(14, starter, 0);
                     draw_eraseval(15);
@@ -640,7 +640,7 @@ class Display {
                     draw_eraseval(11);
                     draw_eraseval(12);
                     draw_eraseval(13);
-                    draw_dynamic(14, airflow_max_mph, 0.0, airflow_abs_max_mph);
+                    draw_dynamic(14, airflow_sensor.get_max_mph(), 0.0, airflow_sensor.get_abs_max_mph());
                     draw_dynamic(15, map_min_psi, map_abs_min_psi, map_abs_max_psi);
                     draw_dynamic(16, map_max_psi, map_abs_min_psi, map_abs_max_psi);
                     draw_dynamic(17, speedo_idle_mph, 0.0, speedometer.get_redline_mph());

--- a/CANTroller2/src/globals.h
+++ b/CANTroller2/src/globals.h
@@ -359,15 +359,7 @@ Timer tachIdleTimer (5000000);  // How often to update tach idle value based on 
 AirflowSensor airflow_sensor(i2c);
 
 // map sensor related
-bool map_detected = false;
-float map_abs_min_psi = 0.88;  // Sensor min
-float map_min_psi = 10.0;  // Typical low map for a car is 10.8 psi = 22 inHg
-float map_max_psi = 15.0;
-float map_abs_max_psi = 36.25;  // Sensor max
-float map_psi = 14.696;  // 1 atm = 14.6959 psi
-float map_filt_psi = map_psi;
-float map_ema_alpha = 0.2;
-SparkFun_MicroPressure map_sensor;
+MAPSensor map_sensor(i2c);
 
 // Motor control:
 // Steering : Controls the steering motor proportionally based on the joystick


### PR DESCRIPTION
Both pretty minor changes, but found and fixed a few things along the way. The AirflowSensor uses i2c, so it doesn't quite fit our current model (it doesn't even have a pin). Still, it does benefit from using ControllerModes to drive it, and it needs filtering and is useful to treat as a device for pot overloading. I think it's okay as-is, but we're starting to get to the point that we could stand to refactor the class hierarchy somewhat, now that we know a lot more about what our end uses are gonna look like.